### PR TITLE
Initial GPU/CPU Pairing Implementation

### DIFF
--- a/FinalProject/CPU.cs
+++ b/FinalProject/CPU.cs
@@ -80,8 +80,6 @@ namespace FinalProject
             Perf1080p = 0;
             DatabaseCode = string.Empty;
             MarketCode = string.Empty;
-            SetMarketLink(MarketCode);
-            SetDatabaseLink(DatabaseCode);
         }
 
         public CPU(string brand, string model, int cores, int threads, double price, int perf1080p, string dbCode, string mktCode)
@@ -94,8 +92,6 @@ namespace FinalProject
             Perf1080p = perf1080p;
             DatabaseCode = dbCode;
             MarketCode = mktCode;
-            SetMarketLink(MarketCode);
-            SetDatabaseLink(DatabaseCode);
         }
 
         public int CompareTo(Object other)

--- a/FinalProject/CPU.cs
+++ b/FinalProject/CPU.cs
@@ -55,15 +55,12 @@ namespace FinalProject
             DatabaseLink = link;
         }
 
-        public override void ShowPerf()
-        {
-            WriteLine("Cores: {0}\n    Threads: {1}", Cores, Threads);
-            WriteLine("Avg. 1080p Performance (w/ RTX 4090): {0} FPS", Perf1080p);
-        }
-
+        // Returns a string showing the core/thread count, benchmark data, and relevant URLs for the CPU
         public override string GetStats()
         {
             string perfInfo = 
+                $"Cores: {Cores}\n" + 
+                $"Threads: {Threads}\n" +
                 $"Avg. 1080p Performance {Perf1080p} FPS\n" +
                 ShowDatabaseLink() + $"{DatabaseLink}\n" +
                 ShowMarketLink() + $"{MarketLink}";

--- a/FinalProject/CPU.cs
+++ b/FinalProject/CPU.cs
@@ -97,5 +97,11 @@ namespace FinalProject
             return (this.Perf1080p.CompareTo(otherCPU.Perf1080p));
         }
 
+        public override string ToString()
+        {
+            string cpuData = GetPartInfo() + GetStats();
+            return cpuData;
+        }
+
     } // CPU class
 }

--- a/FinalProject/ComputerPart.cs
+++ b/FinalProject/ComputerPart.cs
@@ -41,13 +41,21 @@ namespace FinalProject
         public string DatabaseCode
         {
             get { return databaseCode; }
-            set { databaseCode = value; }
+            set 
+            { 
+                databaseCode = value;
+                SetDatabaseLink(databaseCode);
+            }
         }
 
         public string MarketCode
         {
             get { return marketCode; }
-            set { marketCode = value; }
+            set 
+            { 
+                marketCode = value;
+                SetMarketLink(marketCode);
+            }
         }
 
         public string DatabaseLink

--- a/FinalProject/ComputerPart.cs
+++ b/FinalProject/ComputerPart.cs
@@ -71,7 +71,6 @@ namespace FinalProject
 
         public abstract void SetDatabaseLink(string dbCode);
         public abstract void SetMarketLink(string mktCode);
-        public abstract void ShowPerf();
         public abstract string GetStats();
         public string ShowMarketLink()
         {

--- a/FinalProject/Database.cs
+++ b/FinalProject/Database.cs
@@ -10,8 +10,11 @@ namespace FinalProject
     public class Database
     {
         /*  
-         *  Set up the list of GPUs objects to be used for recommendation system
-         *  Object Constructor Design: new GPU(Brand, Model, Price, Perf1080p, Perf1440p, Perf2160p, DatabaseCode, MarketCode) 
+         *  Set up the list of GPU and CPU objects to be used for recommendation system
+         *  GPU Object Design: new GPU(Brand, Model, Price, Perf1080p, Perf1440p, Perf2160p, DatabaseCode, MarketCode) 
+         *  CPU Object Design: new CPU(Brand, Model, Cores, Threads, Price, 1080p Perf, DatabaseCode, MarketCode)
+         *  Benchmark/performance data was manually harvested from latest CPU and GPU reviews on TechPowerUp.com
+         *  Pricing data was harvested from lowest market listing on PCPartPicker.com (last checked Dec 1, 2023)
          */
         private List<GPU> gpuList = new List<GPU>();
 
@@ -19,9 +22,10 @@ namespace FinalProject
 
         public Database()
         {
-            //Creating gpuList that can search through in the other forms
+            // Create the internal GPU List that can be searched through in the other forms
             gpuList = new List<GPU>
             {
+                // NVIDIA GPUs (Ada Lovelace, Ampere & Turing generations)
                 new GPU{ Brand = "NVIDIA", Model = "Geforce RTX 4090", Price = 1600, Perf1080p = 243, Perf1440p = 209, Perf2160p = 133, DatabaseCode = "c3889", MarketCode = "539" },
                 new GPU{ Brand = "NVIDIA", Model = "Geforce RTX 4080", Price = 1199.99, Perf1080p = 214, Perf1440p = 171, Perf2160p = 103, DatabaseCode = "c3888", MarketCode = "542"  },
                 new GPU{ Brand = "NVIDIA", Model = "Geforce RTX 4070 Ti", Price = 729.99, Perf1080p = 187, Perf1440p = 141, Perf2160p = 82, DatabaseCode = "c3950", MarketCode = "549"  },
@@ -35,6 +39,8 @@ namespace FinalProject
                 new GPU{ Brand = "NVIDIA", Model = "Geforce RTX 3060", Price = 289.99, Perf1080p = 81, Perf1440p = 60, Perf2160p = 35, DatabaseCode = "c3682", MarketCode = "499"  },
                 new GPU{ Brand = "NVIDIA", Model = "Geforce RTX 3050", Price = 219.99, Perf1080p = 59, Perf1440p = 43, Perf2160p = 25, DatabaseCode = "c3858", MarketCode = "518"  },
                 new GPU{ Brand = "NVIDIA", Model = "Geforce RTX 2060", Price = 189.99, Perf1080p = 66, Perf1440p = 48, Perf2160p = 26, DatabaseCode = "c3310", MarketCode = "436"  },
+               
+                // AMD GPUs (Navi 3 & Navi 2 generations)
                 new GPU{ Brand = "AMD", Model = "Radeon RX 7900 XTX", Price = 919.99, Perf1080p = 213, Perf1440p = 174, Perf2160p = 108, DatabaseCode = "c3941", MarketCode = "548"  },
                 new GPU{ Brand = "AMD", Model = "Radeon RX 7900 XT", Price = 739.99, Perf1080p = 193, Perf1440p = 152, Perf2160p = 90, DatabaseCode = "c3912", MarketCode = "547"  },
                 new GPU{ Brand = "AMD", Model = "Radeon RX 7800 XT", Price = 499.99, Perf1080p = 157, Perf1440p = 119, Perf2160p = 70, DatabaseCode = "c3839", MarketCode = "559"  },
@@ -46,6 +52,8 @@ namespace FinalProject
                 new GPU{ Brand = "AMD", Model = "Radeon RX 6700 XT", Price = 299.99, Perf1080p = 110, Perf1440p = 82, Perf2160p = 46, DatabaseCode = "c3695", MarketCode = "501"  },
                 new GPU{ Brand = "AMD", Model = "Radeon RX 6600", Price = 189.99, Perf1080p = 77, Perf1440p = 54, Perf2160p = 27, DatabaseCode = "c3696", MarketCode = "511"  },
                 new GPU{ Brand = "AMD", Model = "Radeon RX 6500 XT", Price = 139.99, Perf1080p = 35, Perf1440p = 23, Perf2160p = 11, DatabaseCode = "c3850", MarketCode = "517"  },
+                
+                // Intel GPUs (Alchemist generation)
                 new GPU{ Brand = "Intel", Model = "Arc A770", Price = 199.99, Perf1080p = 92, Perf1440p = 71, Perf2160p = 42, DatabaseCode = "c3914", MarketCode = "540"  },
                 new GPU{ Brand = "Intel", Model = "Arc A750", Price = 169.99, Perf1080p = 82, Perf1440p = 63, Perf2160p = 36, DatabaseCode = "c3929", MarketCode = "541"  },
                 new GPU{ Brand = "Intel", Model = "Arc A580", Price = 159.99, Perf1080p = 74, Perf1440p = 56, Perf2160p = 32, DatabaseCode = "c3928", MarketCode = "561"  },
@@ -53,9 +61,11 @@ namespace FinalProject
 
             };
 
-            //Creating cpuList that can search through in the other forms
+            
+            // Create the internal CPU List that can be searched through in other forms
             cpuList = new List<CPU>
             {
+                // Intel CPUs (12th to 14th gen)
                 new CPU{Brand = "Intel" , Model = "Core i9 14900K", Cores = 24, Threads = 32, Price = 576.99, Perf1080p = 260, DatabaseCode = "c3269", MarketCode = "ZLjRsY"},
                 new CPU{Brand = "Intel" , Model = "Core i7 14700K", Cores = 20, Threads = 28, Price = 401.99, Perf1080p = 252, DatabaseCode = "c3268", MarketCode = "BmWJ7P"},
                 new CPU{Brand = "Intel" , Model = "Core i5 14600K", Cores = 14, Threads = 20, Price = 319.99, Perf1080p = 237, DatabaseCode = "c3266", MarketCode = "jXFmP6"},
@@ -69,6 +79,8 @@ namespace FinalProject
                 new CPU{Brand = "Intel" , Model = "Core i5 12400F", Cores = 6, Threads = 12, Price = 149.95, Perf1080p = 182, DatabaseCode = "c2550", MarketCode = "pQNxFT"},
                 new CPU{Brand = "Intel" , Model = "Core i3 12100", Cores = 4, Threads = 8, Price = 118.95, Perf1080p = 131, DatabaseCode = "c2541", MarketCode = "qrhFf7"},
                 new CPU{Brand = "Intel" , Model = "Core i3 12100F", Cores = 4, Threads = 8, Price = 92.99, Perf1080p = 131, DatabaseCode = "c2543", MarketCode = "grhFf7"},
+                
+                // AMD CPUs (Zen 4 & Zen 3 generations)
                 new CPU{Brand = "AMD" , Model = "Ryzen 9 7950X3D", Cores = 16, Threads = 32, Price = 577.99, Perf1080p = 253, DatabaseCode = "c3024", MarketCode = "X6XV3C"},
                 new CPU{Brand = "AMD" , Model = "Ryzen 9 7950X", Cores = 16, Threads = 32, Price = 564.99, Perf1080p = 231, DatabaseCode = "c2846", MarketCode = "22XJ7P"},
                 new CPU{Brand = "AMD" , Model = "Ryzen 9 7900X", Cores = 12, Threads = 24, Price = 388.96, Perf1080p = 231, DatabaseCode = "c2847", MarketCode = "bwxRsY"},
@@ -87,124 +99,51 @@ namespace FinalProject
         } // Database constructor
 
 
-    //Method to add more GPUs to the list  
-    public void AddGPU(string brand, string model, double price, int perf1080p, int perf1440p, int perf2160p)
-    {
-        GPU newGPU = new GPU
-        { 
-                Brand = brand,
-                Model = model,
-                Price = price,
-                Perf1080p = perf1080p,
-                Perf1440p = perf1440p,
-                Perf2160p = perf2160p
-        };
-
-            gpuList.Add(newGPU);
-     }
-
-    //Method to return items in the gpu list
-    public List<GPU> ReturnGPUs()
-    {
-        return gpuList;
-    }
-//Adds CPU to the cpu list
-    public void AddCPU(string brand, string model, int cores, int threads, double price, int perf1080p, string dbCode, string mktCode)
-    {
-            CPU newCPU = new CPU
-            {
-                Brand = brand,
-                Model = model,
-                Cores = cores,
-                Threads = threads,
-                Price = price,
-                Perf1080p = perf1080p,
-                DatabaseCode = dbCode,
-                MarketCode = mktCode
+        //Method to add more GPUs to the list  
+        public void AddGPU(string brand, string model, double price, int perf1080p, int perf1440p, int perf2160p)
+        {
+            GPU newGPU = new GPU
+            { 
+                    Brand = brand,
+                    Model = model,
+                    Price = price,
+                    Perf1080p = perf1080p,
+                    Perf1440p = perf1440p,
+                    Perf2160p = perf2160p
             };
+
+                gpuList.Add(newGPU);
+         }
+
+        //Method to return items in the gpu list
+        public List<GPU> ReturnGPUs()
+        {
+            return gpuList;
+        }
+
+        //Adds CPU to the cpu list
+        public void AddCPU(string brand, string model, int cores, int threads, double price, int perf1080p, string dbCode, string mktCode)
+        {
+                CPU newCPU = new CPU
+                {
+                    Brand = brand,
+                    Model = model,
+                    Cores = cores,
+                    Threads = threads,
+                    Price = price,
+                    Perf1080p = perf1080p,
+                    DatabaseCode = dbCode,
+                    MarketCode = mktCode
+                };
             
-            cpuList.Add(newCPU);
-    }
+                cpuList.Add(newCPU);
+        }
 
-//Returns the cpu list
-    public List<CPU> ReturnCPUs() 
-    { 
-        return cpuList; 
-    }
-
-    // NVIDIA GPUs
-    GPU RTX_4090 = new GPU("NVIDIA", "Geforce RTX 4090", 1600, 243, 209, 133, "c3889", "539");
-    GPU RTX_4080 = new GPU("NVIDIA", "Geforce RTX 4080", 1199.99, 214, 171, 103, "c3888", "542");
-    GPU RTX_4070Ti = new GPU("NVIDIA", "Geforce RTX 4070 Ti", 729.99, 187, 141, 82, "c3950", "549");
-    GPU RTX_4070 = new GPU("NVIDIA", "Geforce RTX 4070", 539.99, 153, 115, 67, "c3924", "550");
-    GPU RTX_4060Ti = new GPU("NVIDIA", "Geforce RTX 4060 Ti", 369.99, 120, 88, 49, "c3890", "553");
-    GPU RTX_4060 = new GPU("NVIDIA", "Geforce RTX 4060", 299.99, 96, 70, 39, "c4107", "552");
-
-        GPU RTX_3090 = new GPU("NVIDIA", "Geforce RTX 3090", 1356.12, 167, 129, 80, "c3622", "493");
-        GPU RTX_3070Ti = new GPU("NVIDIA", "Geforce RTX 3070 Ti", 499.99, 128, 97, 58, "c3675", "506");
-        GPU RTX_3070 = new GPU("NVIDIA", "Geforce RTX 3070", 399.99, 121, 90, 54, "c3674", "494,508");
-        GPU RTX_3060Ti = new GPU("NVIDIA", "Geforce RTX 3060 Ti", 329.99, 106, 80, 47, "c3681", "497,513");
-        GPU RTX_3060 = new GPU("NVIDIA", "Geforce RTX 3060", 289.99, 81, 60, 35, "c3682", "499");
-        GPU RTX_3050 = new GPU("NVIDIA", "Geforce RTX 3050", 219.99, 59, 43, 25, "c3858", "518");
-        GPU RTX_2060 = new GPU("NVIDIA", "Geforce RTX 2060", 189.99, 66, 48, 26, "c3310", "436");
-
-        // AMD GPUs
-        GPU RX_7900XTX = new GPU("AMD", "Radeon RX 7900 XTX", 919.99, 213, 174, 108, "c3941", "548");
-        GPU RX_7900XT = new GPU("AMD", "Radeon RX 7900 XT", 739.99, 193, 152, 90, "c3912", "547");
-        GPU RX_7800XT = new GPU("AMD", "Radeon RX 7800 XT", 499.99, 157, 119, 70, "c3839", "559");
-        GPU RX_7700XT = new GPU("AMD", "Radeon RX 7700 XT", 429.99, 138, 103, 58, "c3911", "558");
-        GPU RX_7600 = new GPU("AMD", "Radeon RX 7600", 249.99, 94, 68, 35, "c4153", "554");
-
-        GPU RX_6900XT = new GPU("AMD", "Radeon RX 6900 XT", 699.99, 162, 124, 73, "c3481", "498");
-        GPU RX_6800XT = new GPU("AMD", "Radeon RX 6800 XT", 449.99, 153, 117, 68, "c3694", "496");
-        GPU RX_6800 = new GPU("AMD", "Radeon RX 6800", 389.99, 132, 101, 59, "c3713", "495");
-        GPU RX_6700XT = new GPU("AMD", "Radeon RX 6700 XT", 299.99, 110, 82, 46, "c3695", "501");
-        GPU RX_6600 = new GPU("AMD", "Radeon RX 6600", 189.99, 77, 54, 27, "c3696", "511");
-        GPU RX_6500XT = new GPU("AMD", "Radeon RX 6500 XT", 139.99, 35, 23, 11, "c3850", "517");
-
-        // Intel GPUs
-        GPU Arc_A770 = new GPU("Intel", "Arc A770", 199.99, 92, 71, 42, "c3914", "540");
-        GPU Arc_A750 = new GPU("Intel", "Arc A750", 169.99, 82, 63, 36, "c3929", "541");
-        GPU Arc_A580 = new GPU("Intel", "Arc A580", 159.99, 74, 56, 32, "c3928", "561");
-        GPU Arc_A380 = new GPU("Intel", "Arc A380", 99.99, 38, 28, 15, "c3913", "538");
-
-       
-
-        /*
-         * Create the CPU Database
-         * Structure: Brand, Model, Cores, Threads, Price, 1080p Perf, DB Code, Mkt Code
-         */
-
-
-        // Intel
-        CPU Intel_14900K = new CPU("Intel", "Core i9 14900K", 24, 32, 576.99, 260, "c3269", "ZLjRsY");
-        CPU Intel_14700K = new CPU("Intel", "Core i7 14700K", 20, 28, 401.99, 252, "c3268", "BmWJ7P");
-        CPU Intel_14600K = new CPU("Intel", "Core i5 14600K", 14, 20, 319.99, 237, "c3266", "jXFmP6");
-        CPU Intel_13900K = new CPU("Intel", "Core i9 13900K", 24, 32, 546.99, 256, "c2817", "DhVmP6");
-        CPU Intel_13700K = new CPU("Intel", "Core i7 13700K", 24, 32, 345.00, 247, "c2850", "Mm6p99");
-        CPU Intel_13600K = new CPU("Intel", "Core i5 13600K", 14, 20, 270.00, 232, "c2829", "LfNxFT");
-        CPU Intel_13500 = new CPU("Intel", "Core i5 13500", 14, 20, 247.99, 202, "c2851", "mtmmP6");
-        CPU Intel_13400F = new CPU("Intel", "Core i5 13400F", 10, 16, 200.99, 189, "c2995", "VNkWGX");
-        CPU Intel_13100 = new CPU("Intel", "Core i3 13100", 4, 8, 147.99, 134, "c2998", "RdjBD3");
-        CPU Intel_13100F = new CPU("Intel", "Core i3 13100F", 4, 8, 118.99, 134, "c2999", "9MGbt6");
-        CPU Intel_12400F = new CPU("Intel", "Core i5 12400F", 6, 12, 149.95, 182, "c2550", "pQNxFT");
-        CPU Intel_12100 = new CPU("Intel", "Core i3 12100", 4, 8, 118.95, 131, "c2541", "qrhFf7");
-        CPU Intel_12100F = new CPU("Intel", "Core i3 12100F", 4, 8, 92.99, 131, "c2543", "grhFf7");
-
-        // AMD
-        CPU Ryzen_7950X3D = new CPU("AMD", "Ryzen 9 7950X3D", 16, 32, 577.99, 253, "c3024", "X6XV3C");
-        CPU Ryzen_7950X = new CPU("AMD", "Ryzen 9 7950X", 16, 32, 564.99, 231, "c2846", "22XJ7P");
-        CPU Ryzen_7900X = new CPU("AMD", "Ryzen 9 7900X", 12, 24, 388.96, 231, "c2847", "bwxRsY");
-        CPU Ryzen_7800X3D = new CPU("AMD", "Ryzen 7 7800X3D", 8, 16, 358.99, 266, "c3022", "3hyH99");
-        CPU Ryzen_7700X = new CPU("AMD", "Ryzen 7 7700X", 8, 16, 319.00, 235, "c2848", "WfqPxr");
-        CPU Ryzen_7600X = new CPU("AMD", "Ryzen 5 7600X", 6, 12, 209.00, 230, "c2849", "66C48d");
-        CPU Ryzen_5950X = new CPU("AMD", "Ryzen 9 5950X", 16, 32, 433.98, 193, "c2364", "Qk2bt6");
-        CPU Ryzen_5900X = new CPU("AMD", "Ryzen 9 5900X", 12, 24, 288.99, 193, "c2363", "KwLwrH");
-        CPU Ryzen_5800X3D = new CPU("AMD", "Ryzen 7 5800X3D", 8, 16, 322.49, 213, "c2532", "CZ3gXL");
-        CPU Ryzen_5700X = new CPU("AMD", "Ryzen 7 5700X", 8, 16, 169.00, 187, "c2755", "JmhFf7");
-        CPU Ryzen_5600 = new CPU("AMD", "Ryzen 5 5600", 6, 12, 129.99, 182, "c2743", "PgcG3C");
-        CPU Ryzen_5500 = new CPU("AMD", "Ryzen 5 5500", 6, 12, 99.99, 138, "c2756", "PgcG3C");
-        CPU Ryzen_5700G = new CPU("AMD", "Ryzen 7 5700G", 8, 16, 175.70, 156, "c2472", "ycGbt6");
+        //Returns the cpu list
+        public List<CPU> ReturnCPUs() 
+        { 
+            return cpuList; 
+        }
 
     } // Database class
 

--- a/FinalProject/GPU.cs
+++ b/FinalProject/GPU.cs
@@ -72,13 +72,7 @@ namespace FinalProject
             DatabaseLink = link;
         }
 
-        public override void ShowPerf()
-        {
-            WriteLine("Avg. 1080p Performance: {0} FPS", Perf1080p);
-            WriteLine("Avg. 1440p Performance: {0} + FPS", Perf1440p);
-            WriteLine("Avg. 2160p Performance: {0} FPS", Perf2160p);
-        }
-
+        // Returns a string showing the benchmark data and relevant URLs for the GPU
         public override string GetStats()
         {
             string perfInfo = 

--- a/FinalProject/GPU.cs
+++ b/FinalProject/GPU.cs
@@ -57,7 +57,7 @@ namespace FinalProject
         // Manually generates the GPU's Marktetplace URL hosted on PCPartPicker.com
         public override void SetMarketLink(string mktCode)
         {
-            string link = $"https://pcpartpicker.com/products/video-card/#sort=price&c={mktCode}";
+            string link = $"https://pcpartpicker.com/products/video-card/#c={mktCode}&sort=price";
             MarketLink = link;
         }
 
@@ -84,6 +84,11 @@ namespace FinalProject
             return perfInfo;
         }
 
+        public override string ToString()
+        {
+            string gpuData = GetPartInfo() + GetStats();
+            return gpuData;
+        }
     } // GPU class
 
 }

--- a/FinalProject/GPU.cs
+++ b/FinalProject/GPU.cs
@@ -41,9 +41,6 @@ namespace FinalProject
             Perf2160p = 0;
 			MarketCode = string.Empty;
 			DatabaseCode = string.Empty;
-            SetMarketLink(MarketCode);
-            SetDatabaseLink(DatabaseCode);
-
         }
         public GPU(string brand, string model, double price, int perf1080p, int perf1440p, int perf2160p, string dbCode, string mktCode)
         {
@@ -55,8 +52,6 @@ namespace FinalProject
             Perf2160p = perf2160p;
             DatabaseCode = dbCode;
             MarketCode = mktCode;
-            SetMarketLink(MarketCode);
-            SetDatabaseLink(DatabaseCode);
         }
 
         // Manually generates the GPU's Marktetplace URL hosted on PCPartPicker.com
@@ -73,7 +68,7 @@ namespace FinalProject
             string gpuModel = this.Model.ToLower().Replace(" ", "-");
 
             // Generate TechPowerUp link with the provided 4-digit code
-            string link = $"https://www.techpowerup.com/gpu-specs/{gpuModel}.c{dbCode}";
+            string link = $"https://www.techpowerup.com/gpu-specs/{gpuModel}.{dbCode}";
             DatabaseLink = link;
         }
 

--- a/FinalProject/ResultsForm.cs
+++ b/FinalProject/ResultsForm.cs
@@ -24,11 +24,10 @@ namespace FinalProject
         private readonly UserSelection ResultsSelection;
         public ResultsForm(UserSelection selection)
         {
-            Database gpuDatabase = new Database();
-            //Database cpuDatabase = new Database();
+            Database partDatabase = new Database();
 
-            List<GPU> allGPUs = gpuDatabase.ReturnGPUs();
-            //List<CPU> allCPUs = cpuDatabase.ReturnCPUs();
+            List<GPU> allGPUs = partDatabase.ReturnGPUs();
+            List<CPU> allCPUs = partDatabase.ReturnCPUs();
 
             InitializeComponent();
 
@@ -47,9 +46,9 @@ namespace FinalProject
 
             string imagesPath = Path.Combine(imagesLocation, imagesFolder);
 
-            // Sort the GPU list by descending order (1080p by default)
+            // Sort the GPU and CPU lists by descending order (1080p by default)
             GPU[] topGPUs = allGPUs.OrderByDescending(gpu => gpu.Perf1080p).ToArray();
-            //CPU[] topCPUs = allCPUs.ToArray();
+            CPU[] topCPUs = allCPUs.OrderByDescending(cpu => cpu.Perf1080p).ToArray();
 
             // Adjust the List order based on their performance at the selected resolution
             if (resolution == 1080)

--- a/FinalProject/ResultsForm.cs
+++ b/FinalProject/ResultsForm.cs
@@ -11,6 +11,8 @@ using System.Windows.Forms;
 using Newtonsoft.Json;
 using System.IO;
 using System.ComponentModel.Design;
+using System.Drawing.Drawing2D;
+using static System.Diagnostics.Debug;
 
 namespace FinalProject
 {
@@ -48,19 +50,20 @@ namespace FinalProject
 
             // Sort the GPU and CPU lists by descending order (1080p by default)
             GPU[] topGPUs = allGPUs.OrderByDescending(gpu => gpu.Perf1080p).ToArray();
-            CPU[] topCPUs = allCPUs.OrderByDescending(cpu => cpu.Perf1080p).ToArray();
+            CPU[] topCPUs = allCPUs.OrderByDescending(cpu => cpu.Perf1080p).ToArray(); // Can change to sorting by price if preferred 
+            //Array.Sort(topCPUs); // Sort the Top CPUs by their price (TODO: See if this is being sorted properly and fix if incorrect)
 
             // Adjust the List order based on their performance at the selected resolution
             if (resolution == 1080)
             {
                 topGPUs = topGPUs.OrderByDescending(gpu => gpu.Perf1080p)
                    .Where (gpu => (gpu.Price <= budget) && (gpu.Brand == brand) && (gpu.Perf1080p >= fps))
-                   .Take(5)
                    .ToArray();
             }
 
             else if (resolution == 1440)
             {
+                // TODO: Remove Take(5) after pairing optimization is complete
                 topGPUs = topGPUs.OrderByDescending(gpu => gpu.Perf1440p)
                    .Where(gpu => (gpu.Price <= budget) && (gpu.Brand == brand) && (gpu.Perf1440p >= fps))
                    .Take(5)
@@ -69,17 +72,63 @@ namespace FinalProject
 
             else if (resolution == 2160)
             {
+                // TODO: Remove Take(5) after pairing optimization is complete
                 topGPUs = topGPUs.OrderByDescending(gpu => gpu.Perf2160p)
                     .Where(gpu => (gpu.Price <= budget) && (gpu.Brand == brand) && (gpu.Perf2160p >= fps))
                     .Take(5)
                     .ToArray();
             }
 
-            PopulateRichTextBox(topGPUs, imagesPath);
-                        
+            PopulateGPURichTextBox(topGPUs, imagesPath);
+            //PopulateCPURichTextBox(topCPUs, imagesPath);
+            List<(GPU, CPU)> topPairs = new List<(GPU, CPU)>(); // Holds the best CPU/GPU pairs in a list
+
+            // Get the Top 5 GPU/CPU pairs 
+            GetTopPairs(topGPUs, topCPUs, topPairs, budget);
+
+            // Write their info to the Debug terminal (TODO: Remove before submission) 
+            foreach ((GPU gpu,  CPU cpu) in topPairs) 
+            {
+                WriteLine(gpu.ToString());
+                WriteLine(cpu.ToString());
+            }
+            
         }
 
-        private void PopulateRichTextBox(GPU[] topGPUs, string imagePath)
+        private void GetTopPairs(GPU[] topGPUs, CPU[] topCPUs, List<(GPU, CPU)> topPairs, double budget)
+        {
+            // Hold the GPUs and CPUs that were already recommended so they aren't suggested again
+            HashSet <GPU> usedGPUs = new HashSet<GPU>();
+            HashSet <CPU> usedCPUs = new HashSet<CPU>();
+
+            
+            for (int i = 0; i < topGPUs.Length; i++)
+            {
+                for (int j = 0; j < topCPUs.Length; j++)
+                {
+                    // Check if the GPU and CPU pair has already been added
+                    if (!usedGPUs.Contains(topGPUs[i]) && (!usedCPUs.Contains(topCPUs[j])))
+                    {
+                        // Test: Don't use GPUs that take up more than 70% of the total budget (remove or adjust later)
+                        if (topGPUs[i].Price <= (0.7  * budget))
+                        {
+                            double totalPrice = topGPUs[i].Price + topCPUs[j].Price;
+
+                            // Add the pair if it's under budget
+                            if (totalPrice <= budget)
+                            {
+                                topPairs.Add((topGPUs[i], topCPUs[j]));
+                                usedGPUs.Add(topGPUs[i]);
+                                usedCPUs.Add(topCPUs[j]);
+                            }
+                        }
+                    }
+                        
+                }
+            }
+        }
+
+        private void PopulateGPURichTextBox(GPU[] topGPUs, string imagePath)
         {
             for (int i = 0; i < topGPUs.Length; i++)
             {
@@ -89,15 +138,33 @@ namespace FinalProject
 
                 if (richTextBox != null)
                 {
-                    richTextBox.AppendText(gpu.GetPartInfo());
-                    richTextBox.AppendText(gpu.GetStats());
-                    //setting file path for gpu
+                    richTextBox.AppendText(gpu.ToString());
+
+                    //setting file path for GPU
                     string imageFilePath = SearchForImage(imagePath, topGPUs[i].Model.ToString());
-                    //display gpu image
+                    //display GPU image
                     DisplayImage("GPU", imageFilePath, i);
                 }
             }
+        }
 
+        private void PopulateCPURichTextBox(CPU[] topCPUs, string imagePath)
+        {
+            for (int i = 0; i < topCPUs.Length; i++)
+            {
+                CPU cpu = topCPUs[i];
+
+                RichTextBox richTextBox = Controls.Find($"rtbResult{i + 1}", true).FirstOrDefault() as RichTextBox;
+
+                if (richTextBox != null)
+                {
+                    richTextBox.AppendText(cpu.ToString());
+                    //setting file path for CPU
+                    string imageFilePath = SearchForImage(imagePath, topCPUs[i].Model.ToString());
+                    //display CPU image
+                    DisplayImage("CPU", imageFilePath, i);
+                }
+            }
         }
 
         private void DisplayImage(string type, string imagePath, int i)


### PR DESCRIPTION
* Added CPU list construction in the ResultsForm
* Removed unused ShowPerf method from all ComputerPart parent and child classes
* Expanded data to be displayed in CPU's GetStats method
* Removed unused CPU/GPU object constructions in the Database file
* Set procedure to automatically complete the URLs for the Database and Market listings whenever the appropriate codes are set

* Removed duplicate calls to set the Market and Database links within the CPU and GPU constructors
* Fixed issue where the Database URL for the GPU was setting incorrectly (duplicate 'c' character at the end)

* Generated initial GetTopPairs algorithm to get the best GPU and CPU pairs that are under the user's set budget
  - Pairing has only been properly applied to the 1080p setting for testing purposes
  - Top 5 pairs are written to the Debug terminal for testing
* Created CPU equivalent method for populating the RichTextBox
* Optimized TextBox Appending by implementing an override ToString method for the CPU and GPU
* Fixed GPU SetMarketLink issue that was preventing the URL from properly opening the PCPartPicker link
