### PR TITLE
Added URL Opening Feature

### DIFF
--- a/FinalProject/CPU.cs
+++ b/FinalProject/CPU.cs
@@ -100,7 +100,7 @@ namespace FinalProject
 
         public override string ToString()
         {
-            string cpuLabel = "\n\n************ CPU **********\n";
+            string cpuLabel = "************ CPU **********\n";
             string cpuData = cpuLabel + GetPartInfo() + GetStats();
             return cpuData;
         }

--- a/FinalProject/Database.cs
+++ b/FinalProject/Database.cs
@@ -26,7 +26,7 @@ namespace FinalProject
             gpuList = new List<GPU>
             {
                 // NVIDIA GPUs (Ada Lovelace, Ampere & Turing generations)
-                new GPU{ Brand = "NVIDIA", Model = "Geforce RTX 4090", Price = 1600, Perf1080p = 243, Perf1440p = 209, Perf2160p = 133, DatabaseCode = "c3889", MarketCode = "539" },
+                new GPU{ Brand = "NVIDIA", Model = "Geforce RTX 4090", Price = 1599.99, Perf1080p = 243, Perf1440p = 209, Perf2160p = 133, DatabaseCode = "c3889", MarketCode = "539" },
                 new GPU{ Brand = "NVIDIA", Model = "Geforce RTX 4080", Price = 1199.99, Perf1080p = 214, Perf1440p = 171, Perf2160p = 103, DatabaseCode = "c3888", MarketCode = "542"  },
                 new GPU{ Brand = "NVIDIA", Model = "Geforce RTX 4070 Ti", Price = 729.99, Perf1080p = 187, Perf1440p = 141, Perf2160p = 82, DatabaseCode = "c3950", MarketCode = "549"  },
                 new GPU{ Brand = "NVIDIA", Model = "Geforce RTX 4070", Price = 539.99, Perf1080p = 153, Perf1440p = 115, Perf2160p = 67, DatabaseCode = "c3924", MarketCode = "550"  },
@@ -112,7 +112,7 @@ namespace FinalProject
                     Perf2160p = perf2160p
             };
 
-                gpuList.Add(newGPU);
+            gpuList.Add(newGPU);
          }
 
         //Method to return items in the gpu list
@@ -124,19 +124,19 @@ namespace FinalProject
         //Adds CPU to the cpu list
         public void AddCPU(string brand, string model, int cores, int threads, double price, int perf1080p, string dbCode, string mktCode)
         {
-                CPU newCPU = new CPU
-                {
-                    Brand = brand,
-                    Model = model,
-                    Cores = cores,
-                    Threads = threads,
-                    Price = price,
-                    Perf1080p = perf1080p,
-                    DatabaseCode = dbCode,
-                    MarketCode = mktCode
-                };
+            CPU newCPU = new CPU
+            {
+                Brand = brand,
+                Model = model,
+                Cores = cores,
+                Threads = threads,
+                Price = price,
+                Perf1080p = perf1080p,
+                DatabaseCode = dbCode,
+                MarketCode = mktCode
+            };
             
-                cpuList.Add(newCPU);
+            cpuList.Add(newCPU);
         }
 
         //Returns the cpu list

--- a/FinalProject/FinalProject.csproj
+++ b/FinalProject/FinalProject.csproj
@@ -14,6 +14,7 @@
     <None Remove="Images\Arc A580.jpg" />
     <None Remove="Images\Arc A750.jpg" />
     <None Remove="Images\Arc A770.jpg" />
+    <None Remove="Images\Geforce RTX 2060.jpg" />
     <None Remove="Images\Geforce RTX 3050.jpg" />
     <None Remove="Images\Geforce RTX 3060 Ti.jpg" />
     <None Remove="Images\Geforce RTX 3060.jpg" />
@@ -43,6 +44,9 @@
 
   <ItemGroup>
     <Content Include="Images\AMD.jpg">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Images\Geforce RTX 2060.jpg">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="Images\Geforce RTX 3050.jpg">

--- a/FinalProject/GPU.cs
+++ b/FinalProject/GPU.cs
@@ -57,7 +57,7 @@ namespace FinalProject
         // Manually generates the GPU's Marktetplace URL hosted on PCPartPicker.com
         public override void SetMarketLink(string mktCode)
         {
-            string link = $"https://pcpartpicker.com/products/video-card/#c={mktCode}&sort=price";
+            string link = $"https://pcpartpicker.com/products/video-card/#sort=price&c={mktCode}";
             MarketLink = link;
         }
 

--- a/FinalProject/ResultsForm.Designer.cs
+++ b/FinalProject/ResultsForm.Designer.cs
@@ -28,15 +28,15 @@ namespace FinalProject
         /// </summary>
         private void InitializeComponent()
         {
-            rtbResult1 = new RichTextBox();
-            rtbResult2 = new RichTextBox();
+            gpuResult1 = new RichTextBox();
+            gpuResult2 = new RichTextBox();
             pbResult1 = new PictureBox();
             pbResult2 = new PictureBox();
             pbCpu1 = new PictureBox();
             pbCpu2 = new PictureBox();
-            rtbResult3 = new RichTextBox();
-            rtbResult4 = new RichTextBox();
-            rtbResult5 = new RichTextBox();
+            gpuResult3 = new RichTextBox();
+            gpuResult4 = new RichTextBox();
+            gpuResult5 = new RichTextBox();
             pbResult3 = new PictureBox();
             pbResult4 = new PictureBox();
             pbResult5 = new PictureBox();
@@ -49,6 +49,11 @@ namespace FinalProject
             lblPair3 = new Label();
             lblPair4 = new Label();
             lblPair5 = new Label();
+            cpuResult1 = new RichTextBox();
+            cpuResult2 = new RichTextBox();
+            cpuResult3 = new RichTextBox();
+            cpuResult4 = new RichTextBox();
+            cpuResult5 = new RichTextBox();
             ((System.ComponentModel.ISupportInitialize)pbResult1).BeginInit();
             ((System.ComponentModel.ISupportInitialize)pbResult2).BeginInit();
             ((System.ComponentModel.ISupportInitialize)pbCpu1).BeginInit();
@@ -61,142 +66,149 @@ namespace FinalProject
             ((System.ComponentModel.ISupportInitialize)pbCpu5).BeginInit();
             SuspendLayout();
             // 
-            // rtbResult1
+            // gpuResult1
             // 
-            rtbResult1.Location = new Point(18, 33);
-            rtbResult1.Margin = new Padding(2);
-            rtbResult1.Name = "rtbResult1";
-            rtbResult1.Size = new Size(286, 116);
-            rtbResult1.TabIndex = 0;
-            rtbResult1.Text = "";
+            gpuResult1.Location = new Point(22, 41);
+            gpuResult1.Margin = new Padding(2);
+            gpuResult1.Name = "gpuResult1";
+            gpuResult1.Size = new Size(356, 144);
+            gpuResult1.TabIndex = 0;
+            gpuResult1.Text = "";
             // 
-            // rtbResult2
+            // gpuResult2
             // 
-            rtbResult2.Location = new Point(18, 189);
-            rtbResult2.Margin = new Padding(2);
-            rtbResult2.Name = "rtbResult2";
-            rtbResult2.Size = new Size(286, 116);
-            rtbResult2.TabIndex = 1;
-            rtbResult2.Text = "";
+            gpuResult2.Location = new Point(22, 236);
+            gpuResult2.Margin = new Padding(2);
+            gpuResult2.Name = "gpuResult2";
+            gpuResult2.Size = new Size(356, 144);
+            gpuResult2.TabIndex = 1;
+            gpuResult2.Text = "";
             // 
             // pbResult1
             // 
-            pbResult1.Location = new Point(353, 33);
+            pbResult1.Location = new Point(406, 40);
             pbResult1.Margin = new Padding(2);
             pbResult1.Name = "pbResult1";
-            pbResult1.Size = new Size(266, 115);
+            pbResult1.Size = new Size(332, 144);
             pbResult1.TabIndex = 2;
             pbResult1.TabStop = false;
             // 
             // pbResult2
             // 
-            pbResult2.Location = new Point(353, 189);
+            pbResult2.Location = new Point(406, 235);
             pbResult2.Margin = new Padding(2);
             pbResult2.Name = "pbResult2";
-            pbResult2.Size = new Size(266, 115);
+            pbResult2.Size = new Size(332, 144);
             pbResult2.TabIndex = 3;
             pbResult2.TabStop = false;
             // 
             // pbCpu1
             // 
-            pbCpu1.Location = new Point(624, 33);
+            pbCpu1.Location = new Point(1172, 39);
+            pbCpu1.Margin = new Padding(4);
             pbCpu1.Name = "pbCpu1";
-            pbCpu1.Size = new Size(175, 116);
+            pbCpu1.Size = new Size(219, 145);
             pbCpu1.TabIndex = 4;
             pbCpu1.TabStop = false;
             // 
             // pbCpu2
             // 
-            pbCpu2.Location = new Point(624, 189);
+            pbCpu2.Location = new Point(1172, 233);
+            pbCpu2.Margin = new Padding(4);
             pbCpu2.Name = "pbCpu2";
-            pbCpu2.Size = new Size(175, 116);
+            pbCpu2.Size = new Size(219, 145);
             pbCpu2.TabIndex = 5;
             pbCpu2.TabStop = false;
             // 
-            // rtbResult3
+            // gpuResult3
             // 
-            rtbResult3.Location = new Point(18, 346);
-            rtbResult3.Margin = new Padding(2);
-            rtbResult3.Name = "rtbResult3";
-            rtbResult3.Size = new Size(286, 116);
-            rtbResult3.TabIndex = 6;
-            rtbResult3.Text = "";
+            gpuResult3.Location = new Point(22, 432);
+            gpuResult3.Margin = new Padding(2);
+            gpuResult3.Name = "gpuResult3";
+            gpuResult3.Size = new Size(356, 144);
+            gpuResult3.TabIndex = 6;
+            gpuResult3.Text = "";
             // 
-            // rtbResult4
+            // gpuResult4
             // 
-            rtbResult4.Location = new Point(18, 504);
-            rtbResult4.Margin = new Padding(2);
-            rtbResult4.Name = "rtbResult4";
-            rtbResult4.Size = new Size(286, 116);
-            rtbResult4.TabIndex = 7;
-            rtbResult4.Text = "";
+            gpuResult4.Location = new Point(22, 630);
+            gpuResult4.Margin = new Padding(2);
+            gpuResult4.Name = "gpuResult4";
+            gpuResult4.Size = new Size(356, 144);
+            gpuResult4.TabIndex = 7;
+            gpuResult4.Text = "";
             // 
-            // rtbResult5
+            // gpuResult5
             // 
-            rtbResult5.Location = new Point(18, 657);
-            rtbResult5.Margin = new Padding(2);
-            rtbResult5.Name = "rtbResult5";
-            rtbResult5.Size = new Size(286, 116);
-            rtbResult5.TabIndex = 8;
-            rtbResult5.Text = "";
+            gpuResult5.Location = new Point(22, 821);
+            gpuResult5.Margin = new Padding(2);
+            gpuResult5.Name = "gpuResult5";
+            gpuResult5.Size = new Size(356, 144);
+            gpuResult5.TabIndex = 8;
+            gpuResult5.Text = "";
             // 
             // pbResult3
             // 
-            pbResult3.Location = new Point(353, 347);
+            pbResult3.Location = new Point(406, 433);
             pbResult3.Margin = new Padding(2);
             pbResult3.Name = "pbResult3";
-            pbResult3.Size = new Size(266, 115);
+            pbResult3.Size = new Size(332, 144);
             pbResult3.TabIndex = 9;
             pbResult3.TabStop = false;
             // 
             // pbResult4
             // 
-            pbResult4.Location = new Point(353, 505);
+            pbResult4.Location = new Point(406, 628);
             pbResult4.Margin = new Padding(2);
             pbResult4.Name = "pbResult4";
-            pbResult4.Size = new Size(266, 115);
+            pbResult4.Size = new Size(332, 144);
             pbResult4.TabIndex = 10;
             pbResult4.TabStop = false;
             // 
             // pbResult5
             // 
-            pbResult5.Location = new Point(353, 658);
+            pbResult5.Location = new Point(406, 821);
             pbResult5.Margin = new Padding(2);
             pbResult5.Name = "pbResult5";
-            pbResult5.Size = new Size(266, 115);
+            pbResult5.Size = new Size(332, 144);
             pbResult5.TabIndex = 11;
             pbResult5.TabStop = false;
             // 
             // pbCpu3
             // 
-            pbCpu3.Location = new Point(624, 347);
+            pbCpu3.Location = new Point(1172, 431);
+            pbCpu3.Margin = new Padding(4);
             pbCpu3.Name = "pbCpu3";
-            pbCpu3.Size = new Size(175, 116);
+            pbCpu3.Size = new Size(219, 145);
             pbCpu3.TabIndex = 12;
             pbCpu3.TabStop = false;
             // 
             // pbCpu4
             // 
-            pbCpu4.Location = new Point(624, 505);
+            pbCpu4.Location = new Point(1172, 628);
+            pbCpu4.Margin = new Padding(4);
             pbCpu4.Name = "pbCpu4";
-            pbCpu4.Size = new Size(175, 116);
+            pbCpu4.Size = new Size(219, 145);
             pbCpu4.TabIndex = 13;
             pbCpu4.TabStop = false;
             // 
             // pbCpu5
             // 
-            pbCpu5.Location = new Point(624, 658);
+            pbCpu5.Location = new Point(1172, 819);
+            pbCpu5.Margin = new Padding(4);
             pbCpu5.Name = "pbCpu5";
-            pbCpu5.Size = new Size(175, 116);
+            pbCpu5.Size = new Size(219, 145);
             pbCpu5.TabIndex = 14;
             pbCpu5.TabStop = false;
             // 
             // btnClose
             // 
+            btnClose.Anchor = AnchorStyles.Bottom;
             btnClose.Font = new Font("Segoe UI", 9F, FontStyle.Bold);
-            btnClose.Location = new Point(353, 817);
+            btnClose.Location = new Point(690, 1017);
+            btnClose.Margin = new Padding(4);
             btnClose.Name = "btnClose";
-            btnClose.Size = new Size(94, 29);
+            btnClose.Size = new Size(118, 36);
             btnClose.TabIndex = 15;
             btnClose.Text = "Close";
             btnClose.UseVisualStyleBackColor = true;
@@ -207,9 +219,10 @@ namespace FinalProject
             lblPair1.AutoSize = true;
             lblPair1.Font = new Font("Segoe UI", 9F, FontStyle.Bold);
             lblPair1.ForeColor = SystemColors.HotTrack;
-            lblPair1.Location = new Point(18, 151);
+            lblPair1.Location = new Point(22, 189);
+            lblPair1.Margin = new Padding(4, 0, 4, 0);
             lblPair1.Name = "lblPair1";
-            lblPair1.Size = new Size(0, 20);
+            lblPair1.Size = new Size(0, 25);
             lblPair1.TabIndex = 16;
             // 
             // lblPair2
@@ -217,9 +230,10 @@ namespace FinalProject
             lblPair2.AutoSize = true;
             lblPair2.Font = new Font("Segoe UI", 9F, FontStyle.Bold);
             lblPair2.ForeColor = SystemColors.HotTrack;
-            lblPair2.Location = new Point(18, 307);
+            lblPair2.Location = new Point(22, 384);
+            lblPair2.Margin = new Padding(4, 0, 4, 0);
             lblPair2.Name = "lblPair2";
-            lblPair2.Size = new Size(0, 20);
+            lblPair2.Size = new Size(0, 25);
             lblPair2.TabIndex = 17;
             // 
             // lblPair3
@@ -227,9 +241,10 @@ namespace FinalProject
             lblPair3.AutoSize = true;
             lblPair3.Font = new Font("Segoe UI", 9F, FontStyle.Bold);
             lblPair3.ForeColor = SystemColors.HotTrack;
-            lblPair3.Location = new Point(18, 464);
+            lblPair3.Location = new Point(22, 580);
+            lblPair3.Margin = new Padding(4, 0, 4, 0);
             lblPair3.Name = "lblPair3";
-            lblPair3.Size = new Size(0, 20);
+            lblPair3.Size = new Size(0, 25);
             lblPair3.TabIndex = 18;
             // 
             // lblPair4
@@ -237,9 +252,10 @@ namespace FinalProject
             lblPair4.AutoSize = true;
             lblPair4.Font = new Font("Segoe UI", 9F, FontStyle.Bold);
             lblPair4.ForeColor = SystemColors.HotTrack;
-            lblPair4.Location = new Point(18, 622);
+            lblPair4.Location = new Point(22, 778);
+            lblPair4.Margin = new Padding(4, 0, 4, 0);
             lblPair4.Name = "lblPair4";
-            lblPair4.Size = new Size(0, 20);
+            lblPair4.Size = new Size(0, 25);
             lblPair4.TabIndex = 19;
             // 
             // lblPair5
@@ -247,16 +263,67 @@ namespace FinalProject
             lblPair5.AutoSize = true;
             lblPair5.Font = new Font("Segoe UI", 9F, FontStyle.Bold);
             lblPair5.ForeColor = SystemColors.HotTrack;
-            lblPair5.Location = new Point(18, 775);
+            lblPair5.Location = new Point(22, 969);
+            lblPair5.Margin = new Padding(4, 0, 4, 0);
             lblPair5.Name = "lblPair5";
-            lblPair5.Size = new Size(0, 20);
+            lblPair5.Size = new Size(0, 25);
             lblPair5.TabIndex = 20;
+            // 
+            // cpuResult1
+            // 
+            cpuResult1.Location = new Point(783, 41);
+            cpuResult1.Margin = new Padding(2);
+            cpuResult1.Name = "cpuResult1";
+            cpuResult1.Size = new Size(356, 144);
+            cpuResult1.TabIndex = 21;
+            cpuResult1.Text = "";
+            // 
+            // cpuResult2
+            // 
+            cpuResult2.Location = new Point(783, 236);
+            cpuResult2.Margin = new Padding(2);
+            cpuResult2.Name = "cpuResult2";
+            cpuResult2.Size = new Size(356, 144);
+            cpuResult2.TabIndex = 22;
+            cpuResult2.Text = "";
+            // 
+            // cpuResult3
+            // 
+            cpuResult3.Location = new Point(783, 431);
+            cpuResult3.Margin = new Padding(2);
+            cpuResult3.Name = "cpuResult3";
+            cpuResult3.Size = new Size(356, 144);
+            cpuResult3.TabIndex = 23;
+            cpuResult3.Text = "";
+            // 
+            // cpuResult4
+            // 
+            cpuResult4.Location = new Point(783, 629);
+            cpuResult4.Margin = new Padding(2);
+            cpuResult4.Name = "cpuResult4";
+            cpuResult4.Size = new Size(356, 144);
+            cpuResult4.TabIndex = 24;
+            cpuResult4.Text = "";
+            // 
+            // cpuResult5
+            // 
+            cpuResult5.Location = new Point(783, 819);
+            cpuResult5.Margin = new Padding(2);
+            cpuResult5.Name = "cpuResult5";
+            cpuResult5.Size = new Size(356, 144);
+            cpuResult5.TabIndex = 25;
+            cpuResult5.Text = "";
             // 
             // ResultsForm
             // 
-            AutoScaleDimensions = new SizeF(8F, 20F);
+            AutoScaleDimensions = new SizeF(10F, 25F);
             AutoScaleMode = AutoScaleMode.Font;
-            ClientSize = new Size(822, 870);
+            ClientSize = new Size(1423, 1088);
+            Controls.Add(cpuResult5);
+            Controls.Add(cpuResult4);
+            Controls.Add(cpuResult3);
+            Controls.Add(cpuResult2);
+            Controls.Add(cpuResult1);
             Controls.Add(lblPair5);
             Controls.Add(lblPair4);
             Controls.Add(lblPair3);
@@ -269,16 +336,17 @@ namespace FinalProject
             Controls.Add(pbResult5);
             Controls.Add(pbResult4);
             Controls.Add(pbResult3);
-            Controls.Add(rtbResult5);
-            Controls.Add(rtbResult4);
-            Controls.Add(rtbResult3);
+            Controls.Add(gpuResult5);
+            Controls.Add(gpuResult4);
+            Controls.Add(gpuResult3);
             Controls.Add(pbCpu2);
             Controls.Add(pbCpu1);
             Controls.Add(pbResult2);
             Controls.Add(pbResult1);
-            Controls.Add(rtbResult2);
-            Controls.Add(rtbResult1);
+            Controls.Add(gpuResult2);
+            Controls.Add(gpuResult1);
             Margin = new Padding(2);
+            MaximizeBox = false;
             Name = "ResultsForm";
             Text = "Recommendations";
             ((System.ComponentModel.ISupportInitialize)pbResult1).EndInit();
@@ -297,15 +365,15 @@ namespace FinalProject
 
         #endregion
 
-        private RichTextBox rtbResult1;
-        private RichTextBox rtbResult2;
+        private RichTextBox gpuResult1;
+        private RichTextBox gpuResult2;
         private PictureBox pbResult1;
         private PictureBox pbResult2;
         private PictureBox pbCpu1;
         private PictureBox pbCpu2;
-        private RichTextBox rtbResult3;
-        private RichTextBox rtbResult4;
-        private RichTextBox rtbResult5;
+        private RichTextBox gpuResult3;
+        private RichTextBox gpuResult4;
+        private RichTextBox gpuResult5;
         private PictureBox pbResult3;
         private PictureBox pbResult4;
         private PictureBox pbResult5;
@@ -318,5 +386,10 @@ namespace FinalProject
         private Label lblPair3;
         private Label lblPair4;
         private Label lblPair5;
+        private RichTextBox cpuResult1;
+        private RichTextBox cpuResult2;
+        private RichTextBox cpuResult3;
+        private RichTextBox cpuResult4;
+        private RichTextBox cpuResult5;
     }
 }

--- a/FinalProject/ResultsForm.cs
+++ b/FinalProject/ResultsForm.cs
@@ -17,6 +17,8 @@ using System.Globalization;
 using static System.Windows.Forms.LinkLabel;
 using static System.Web.HttpUtility;
 using static System.Diagnostics.Process;
+using System.Runtime.InteropServices;
+using System.Security.Policy;
 
 namespace FinalProject
 {
@@ -187,10 +189,31 @@ namespace FinalProject
         // Opens the provided URL in the computer's default web browser 
         private void OpenURL(string link)
         {
-            
-            string encodedURL = Uri.EscapeUriString(link);
-            
-            Process.Start(encodedURL);
+            try
+            {
+                Process.Start(link);
+            }
+            catch
+            {
+                // Troubleshooting URL-opening code harvested from this: https://github.com/dotnet/corefx/issues/10361
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                {
+                    link = link.Replace("&", "^&");
+                    Process.Start(new ProcessStartInfo(link) { UseShellExecute = true });
+                }
+                else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                {
+                    Process.Start("xdg-open", link);
+                }
+                else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                {
+                    Process.Start("open", link);
+                }
+                else
+                {
+                    throw;
+                }
+            }
         }
 
         private void DisplayImage(string type, string imagePath, int i)

--- a/FinalProject/ResultsForm.cs
+++ b/FinalProject/ResultsForm.cs
@@ -144,7 +144,7 @@ namespace FinalProject
         /*
          * Add the relevant GPU and CPU data from the to the pairs to the rich text boxes
          * Each pair populates a single text box, and displays their assigned images
-         * next to each row of pairs
+         * next to each row of pairs. Combined pair prices will be displayed below each pair
          */
         private void PopulateRichTextBox(List<(GPU, CPU)> topPairs, string imagePath)
         {
@@ -162,16 +162,18 @@ namespace FinalProject
                     richTextBox.AppendText(gpu.ToString());
                     richTextBox.AppendText(cpu.ToString());
 
-                    // Event handler for when a URL is clicked
+                    // Force the text box to detect URLs; add event handler for when a URL is clicked
                     richTextBox.DetectUrls = true;
                     richTextBox.LinkClicked += HyperLinkClicked;
 
                     // Setting file path for GPU
                     string gpuImagePath = SearchForImage(imagePath, gpu.Model.ToString());
                     string cpuImagePath = SearchForImage(imagePath, cpu.Brand.ToString());
+
                     // Display GPU and CPU images
                     DisplayImage("GPU", gpuImagePath, i);
                     DisplayImage("CPU", cpuImagePath, i);
+
                     //Display Pairs and Total on label underneath Rich Text Box
                     pairTotal = gpu.Price + cpu.Price;
                     pairString = String.Format("{0} {1} + {2} {3} Total: {4}", gpu.Brand, gpu.Model, cpu.Brand, cpu.Model, pairTotal.ToString("C", CultureInfo.GetCultureInfo("en-US")));
@@ -198,7 +200,7 @@ namespace FinalProject
                 // Troubleshooting URL-opening code harvested from this: https://github.com/dotnet/corefx/issues/10361
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 {
-                    link = link.Replace("&", "^&");
+                    //link = link.Replace("&", "&");
                     Process.Start(new ProcessStartInfo(link) { UseShellExecute = true });
                 }
                 else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))

--- a/FinalProject/ResultsForm.cs
+++ b/FinalProject/ResultsForm.cs
@@ -154,17 +154,20 @@ namespace FinalProject
 
             foreach ((GPU gpu, CPU cpu) in topPairs)
             {
-                RichTextBox richTextBox = Controls.Find($"rtbResult{i + 1}", true).FirstOrDefault() as RichTextBox;
+                RichTextBox richTextBoxGPU = Controls.Find($"gpuResult{i + 1}", true).FirstOrDefault() as RichTextBox;
+                RichTextBox richTextBoxCPU = Controls.Find($"cpuResult{i + 1}", true).FirstOrDefault() as RichTextBox;
                 Label labelText = Controls.Find($"lblPair{i + 1}", true).FirstOrDefault() as Label;
 
-                if (richTextBox != null)
+                if (richTextBoxGPU != null && richTextBoxCPU != null)
                 {
-                    richTextBox.AppendText(gpu.ToString());
-                    richTextBox.AppendText(cpu.ToString());
+                    richTextBoxGPU.AppendText(gpu.ToString());
+                    richTextBoxCPU.AppendText(cpu.ToString());
 
                     // Force the text box to detect URLs; add event handler for when a URL is clicked
-                    richTextBox.DetectUrls = true;
-                    richTextBox.LinkClicked += HyperLinkClicked;
+                    richTextBoxGPU.DetectUrls = true;
+                    richTextBoxGPU.LinkClicked += HyperLinkClicked;
+                    richTextBoxCPU.DetectUrls = true;
+                    richTextBoxCPU.LinkClicked += HyperLinkClicked;
 
                     // Setting file path for GPU
                     string gpuImagePath = SearchForImage(imagePath, gpu.Model.ToString());
@@ -184,7 +187,7 @@ namespace FinalProject
         }
 
         private void HyperLinkClicked(Object sender, LinkClickedEventArgs e)
-        { 
+        {
             OpenURL(e.LinkText);
         }
 

--- a/FinalProject/ResultsForm.cs
+++ b/FinalProject/ResultsForm.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Data;
@@ -12,8 +12,11 @@ using Newtonsoft.Json;
 using System.IO;
 using System.ComponentModel.Design;
 using System.Drawing.Drawing2D;
-using static System.Diagnostics.Debug;
+using System.Diagnostics;
 using System.Globalization;
+using static System.Windows.Forms.LinkLabel;
+using static System.Web.HttpUtility;
+using static System.Diagnostics.Process;
 
 namespace FinalProject
 {
@@ -156,6 +159,11 @@ namespace FinalProject
                 {
                     richTextBox.AppendText(gpu.ToString());
                     richTextBox.AppendText(cpu.ToString());
+
+                    // Event handler for when a URL is clicked
+                    richTextBox.DetectUrls = true;
+                    richTextBox.LinkClicked += HyperLinkClicked;
+
                     // Setting file path for GPU
                     string gpuImagePath = SearchForImage(imagePath, gpu.Model.ToString());
                     string cpuImagePath = SearchForImage(imagePath, cpu.Brand.ToString());
@@ -169,6 +177,20 @@ namespace FinalProject
                 }
                 i++;
             }
+        }
+
+        private void HyperLinkClicked(Object sender, LinkClickedEventArgs e)
+        { 
+            OpenURL(e.LinkText);
+        }
+
+        // Opens the provided URL in the computer's default web browser 
+        private void OpenURL(string link)
+        {
+            
+            string encodedURL = Uri.EscapeUriString(link);
+            
+            Process.Start(encodedURL);
         }
 
         private void DisplayImage(string type, string imagePath, int i)


### PR DESCRIPTION
* Resolved '&' issue that was causing the PC Part Picker link to not filter GPU cards properly when the page initially opens
* Implemented URL-opening precautions for all 3 major OS' from GitHub page in the comments
* Updated RTX 4090 price to a double value
* Created separate text boxes for the CPU in the Results Form to hold their stats and URLs
* Fixed issue where the RTX 2060 image was not being displayed